### PR TITLE
InfoAreaの作成

### DIFF
--- a/BaseArea.pde
+++ b/BaseArea.pde
@@ -1,0 +1,17 @@
+class BaseArea extends AbstractArea {
+
+  BaseArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+
+  void draw() {
+    for (int i=posX; i< posX+yoko; i++) {
+      for (int j=posY; j< posY+tate; j++) {
+        fill(#ffffc5);
+        if (i==posX) fill(#c5ffc5);
+        else if (i==posX+yoko-1) fill(#c5ffff);
+        rect(i*SQUARESIZE, j*SQUARESIZE, SQUARESIZE, SQUARESIZE);
+      }
+    }
+  }
+}

--- a/InfoArea.pde
+++ b/InfoArea.pde
@@ -1,0 +1,12 @@
+class InfoArea extends AbstractArea {
+  InfoArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+  void draw() {
+    fill(#FFFFFF);
+    rect(posX*SQUARESIZE, posY*SQUARESIZE, yoko*SQUARESIZE, tate*SQUARESIZE);
+    fill(#000000);
+    textSize(20);
+    text("<- Left turn", (posX+0.3)*SQUARESIZE, (posY+0.5)*SQUARESIZE);
+  }
+}

--- a/MochigomaArea.pde
+++ b/MochigomaArea.pde
@@ -1,0 +1,13 @@
+class MochigomaArea extends AbstractArea {
+  MochigomaArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+  void draw() {
+    for (int i=posX; i<posX+yoko; i++) {
+      for (int j=posY; j<posY+tate; j++) {
+        fill(#dddddd);
+        rect(i*SQUARESIZE, j*SQUARESIZE, SQUARESIZE, SQUARESIZE);
+      }
+    }
+  }
+}


### PR DESCRIPTION
AbstractAreaクラスを継承する．
親クラス（AbstractAreaクラス）で定義されたエリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)を親クラスのコンストラクタ(super(int posX, int posY, int yoko, int tate))を利用して初期化する．
親クラスで定義された抽象メソッドvoid draw()を実装する．
エリア内は白字に黒文字．
起動時はLeftのTurnであることを示す文字を左寄りに表示する．